### PR TITLE
Defining RADIO_APRS_PAYLOAD_MAX_LENGTH

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -248,6 +248,7 @@ Setting, measured RF output power, relative DC power draw
 // Maximum length: depends on the packet contents, but keeping this under 100 characters is usually safe.
 // Note that many hardware APRS receivers show a limited number of APRS comment characters, such as 43 or 67 chars.
 // The max APRS packet length (including all settings below) cannot exceed 192 characters. 
+#define RADIO_APRS_PAYLOAD_MAX_LENGTH 192
 #define APRS_COMMENT "https://amateur.sondehub.org/" CALLSIGN
 #define APRS_RELAYS "" // No spaces. This is where you can define "WIDE1-1,WIDE2-1" etc, but it is highly discouraged for balloons.
 #define APRS_DESTINATION "APZ41N"


### PR DESCRIPTION
Define was missing for RADIO_APRS_PAYLOAD_MAX_LENGTH preventing successful build.